### PR TITLE
enables mermaid for diagrams

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,3 +7,6 @@ url: https://dutawas.com
 
 aux_links:
   Template Repository: https://github.com/kshitu92/dutawas
+
+mermaid:
+  version: ">=11.4.1"

--- a/_includes/mermaid_config.js
+++ b/_includes/mermaid_config.js
@@ -1,0 +1,3 @@
+{
+    theme: "default",
+}

--- a/index.md
+++ b/index.md
@@ -4,3 +4,19 @@ layout: home
 ---
 
 Welcome!
+
+<!-- Markdown -->
+```mermaid
+graph TD;
+    A-->B;
+    A-->C;
+    B-->D;
+    C-->D;
+```  
+<!-- Markup -->
+<pre class="mermaid">
+    graph LR
+    A --- B
+    B-->C[fa:fa-ban forbidden]
+    B-->D(fa:fa-spinner);
+</pre>


### PR DESCRIPTION
- Just The Docs already supports Mermaid by default. It just needs to be [enabled from `_config.yml`](https://just-the-docs.com/docs/ui-components/code/#mermaid-diagram-code-blocks).
- `mermaid_config.js` handles the configuration of Mermaid in Just The Docs. Currently, I used it to configure Mermaid with the default theme.