### PR TITLE
content: verify + expand consulate pages, improve homepage, add community feedback system

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_content.md
+++ b/.github/ISSUE_TEMPLATE/new_content.md
@@ -1,0 +1,20 @@
+---
+name: Suggest New Content
+about: Suggest a new page, section, or consulate to add
+title: "New Content: [DESCRIPTION]"
+labels: enhancement
+assignees: ''
+---
+
+**What content would you like to see added?**
+
+
+**Why would this be useful to the community?**
+
+
+**Do you have sources or links for this information?**
+
+
+**Are you willing to help write this content?**
+- [ ] Yes, I can write it
+- [ ] No, just suggesting

--- a/.github/ISSUE_TEMPLATE/outdated_info.md
+++ b/.github/ISSUE_TEMPLATE/outdated_info.md
@@ -1,0 +1,19 @@
+---
+name: Flag Outdated Information
+about: Report information on the site that is wrong or needs updating
+title: "Outdated Info: [PAGE NAME]"
+labels: outdated
+assignees: ''
+---
+
+**Which page has outdated information?**
+(e.g., New York Consulate, Dallas Consulate)
+
+**What is outdated or incorrect?**
+(e.g., Phone number has changed, office hours are wrong, fee amount is different)
+
+**What is the correct information?**
+(Fill in if you know it)
+
+**Source for the correct information:**
+(e.g., official website URL, or "I visited the consulate on [date]")

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ __pycache__/
 *$py.class
 
 # .github/scripts/__pycache__
+CLAUDE_CONTEXT.md
+CONTRIBUTION_PLAN.md
+.DS_Store
+.ruby-version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,111 @@
+# Contributing to Dutawas
+
+Thank you for helping keep consulate information accurate for the Nepali community! There are several ways to contribute, and **you do not need to know how to code** for most of them.
+
+## Report Outdated Information (No Coding Needed)
+
+If you notice something wrong or outdated on the site:
+
+1. Go to [github.com/kshitu92/dutawas/issues/new](https://github.com/kshitu92/dutawas/issues/new?template=outdated_info.md)
+2. Select the **"Flag Outdated Information"** template
+3. Fill in what is wrong and what the correct information is
+4. Submit — a maintainer will review and update the site
+
+You can also click the **"Help keep this page accurate"** link at the bottom of any consulate page.
+
+## Suggest New Content (No Coding Needed)
+
+Want to see a new consulate, service, or page added?
+
+1. Go to [github.com/kshitu92/dutawas/issues/new](https://github.com/kshitu92/dutawas/issues/new?template=new_content.md)
+2. Select the **"Suggest New Content"** template
+3. Describe what you want added and why it would be useful
+4. Include any source links if you have them
+
+## Edit a Page Using GitHub's Web Editor (No Local Setup)
+
+For small edits like fixing a typo or updating a phone number:
+
+1. Navigate to the page's `.md` file in the [GitHub repository](https://github.com/kshitu92/dutawas)
+   - Consulate pages are in the `consulates/` folder
+2. Click the **pencil icon** (Edit this file) in the top right
+3. Make your change
+4. Click **"Propose changes"** at the bottom
+5. Click **"Create pull request"**
+6. A maintainer will review and merge your change
+
+## Add a New Consulate Page
+
+If you want to add a new consulate or embassy page:
+
+### File naming
+
+Create a new `.md` file in the `consulates/` folder. Use lowercase, hyphen-separated names:
+- `consulates/washington-dc.md`
+- `consulates/chicago.md`
+
+### Required frontmatter
+
+Every consulate page must start with:
+
+```yaml
+---
+title: [Consulate Name]
+layout: default
+nav_order: [number]
+parent: Consulates
+permalink: /consulates/[slug]/
+last_verified: [YYYY-MM-DD]
+verified_by: [your_github_username]
+---
+```
+
+### Required sections
+
+Follow this structure (match existing pages):
+
+1. **Location and Contact Information** — address, phone, email, office hours
+2. **Services Provided** — bullet list
+3. **Jurisdiction** — which states/areas this consulate serves
+4. **Fee Schedule** — table format, with source
+5. **Document Checklists** — checklist format for major services
+6. **Appointment Booking** — how to schedule
+7. **Important Information** — notable rules and tips
+8. **Forms and Documents** — links to official forms
+9. **Frequently Asked Questions** — Q&A format
+10. **Sources** — official URLs with last-checked dates
+
+### Content rules
+
+- **Never invent information.** If you are not sure of a fee, phone number, or policy, write "Check with consulate for current information" rather than guessing.
+- **Always include sources.** Every page must have a Sources section listing where information was verified and when.
+- **Use official embassy/consulate websites** as primary sources (listed in the site's about page).
+
+## Run the Site Locally (For Developers)
+
+See the [README](README.md) for instructions on running the site locally with Jekyll.
+
+Quick start:
+```bash
+git clone https://github.com/YOUR_USERNAME/dutawas.git
+cd dutawas
+bundle install
+bundle exec jekyll serve
+# Open http://localhost:4000
+```
+
+## Pull Request Checklist
+
+Before submitting a PR, confirm:
+
+- [ ] Information is accurate and sourced from official websites
+- [ ] Sources section is included with last-checked dates
+- [ ] Page follows the existing structure and formatting style
+- [ ] Frontmatter includes `last_verified` and `verified_by` fields
+- [ ] No broken links
+- [ ] Fees say "Check with consulate" if you are not 100% certain
+- [ ] PR description explains what changed and why
+
+## Questions?
+
+Open an issue or reach out to the maintainer [@kshitu92](https://github.com/kshitu92).

--- a/consulates/boston.md
+++ b/consulates/boston.md
@@ -4,6 +4,8 @@ layout: default
 nav_order: 3
 parent: Consulates
 permalink: /consulates/boston/
+last_verified: 2026-03-16
+verified_by: bishantt
 ---
 # Consulate General of Nepal — Boston
 
@@ -15,16 +17,39 @@ Massachusetts (along with Connecticut, Maine, New Hampshire, New Jersey, New Yor
 
 For all consular services, including passport renewal, visa, NRN ID card, and document attestation, residents of Massachusetts should visit or contact:
 
-**Consulate General of Nepal, New York**  
-820 Second Avenue, Suite 202  
+**Consulate General of Nepal, New York**
+228 E 45th Street, 4th Floor  
 New York, NY 10017  
-Phone: +1 (212) 370-3988  
+Phone: +1 (917) 675-6783  
 Email: cgnnewyork@mofa.gov.np  
 Website: [nyc.nepalconsulate.gov.np](https://nyc.nepalconsulate.gov.np)
 
-The New York consulate also holds periodic **Consular Service Camps** in New England states, including New Hampshire and Connecticut. Check the [New York consulate website](https://nyc.nepalconsulate.gov.np) for upcoming camp dates.
+## Consular Service Camps in New England
+
+The New York consulate holds periodic **Consular Service Camps** in New England states, bringing services closer to residents who cannot easily travel to New York. Recent camps have been held in New Hampshire, Connecticut, and Pennsylvania.
+
+**How to check for upcoming camps:**
+1. Visit [nyc.nepalconsulate.gov.np](https://nyc.nepalconsulate.gov.np) and check the announcements section
+2. Follow the consulate's social media for camp date announcements
+3. Email cgnnewyork@mofa.gov.np for the latest schedule
+
+**What to bring to a service camp:**
+- The same documents required for in-person visits at the New York consulate
+- See the [New York consulate page](/consulates/new-york/) for detailed document checklists by service type
+
+## Mail-In Services
+
+Some services can be completed by mail without traveling to New York. Include a self-addressed, pre-paid return envelope with tracking. Contact the consulate to confirm which services accept mail-in applications.
 
 ## Sources
 
-- [Consulate General of Nepal, New York — e-Passport page](https://nyc.nepalconsulate.gov.np/pages/e-passport-1) — jurisdiction states confirmed: March 2026
+- [Consulate General of Nepal, New York — E-Passport Page](https://nyc.nepalconsulate.gov.np/pages/e-passport-1) — Jurisdiction states confirmed: March 2026
 - [Consulate General of Nepal, New York Official Website](https://nyc.nepalconsulate.gov.np) — Last checked: March 2026
+  - Consular camp announcements (Pennsylvania and New Hampshire camps confirmed)
+
+---
+
+> **Help keep this page accurate.**
+> Found something wrong or outdated? [Report it here](https://github.com/kshitu92/dutawas/issues/new?template=outdated_info.md&title=Outdated+Info:+Boston&labels=outdated).
+
+---

--- a/consulates/dallas.md
+++ b/consulates/dallas.md
@@ -4,26 +4,28 @@ layout: default
 nav_order: 4
 parent: Consulates
 permalink: /consulates/dallas/
+last_verified: 2026-03-16
+verified_by: bishantt
 ---
 # Consulate General of Nepal in Dallas
 
 ## Location and Contact Information
 
-*Address:*  
+**Address:**  
 1230 River Bend Drive, Suite 220  
 Dallas, TX 75247  
 United States of America
 
-*Phone:*  
+**Phone:**  
 +1 (972) 803-5394
 
-*Email:*  
+**Email:**  
 info@nepalconsulatedallas.org (General inquiries)  
 passport@nepalconsulatedallas.org (Passport services)  
 consular@nepalconsulatedallas.org (Document attestation and consular queries)  
 secretary@nepalconsulatedallas.org (Power of Attorney)
 
-*Office Hours:*  
+**Office Hours:**  
 Monday to Friday: 9:00 AM - 5:00 PM  
 Consular Attestation Window: 10:00 AM - 12:30 PM  
 Passport Application: By appointment (as scheduled)  
@@ -31,23 +33,115 @@ Lunch Break: 1:00 PM - 2:00 PM
 
 ## Services Provided
 
-- Passport Service
-- Visa Service
+- Passport Services (E-Passport)
+- Visa Services
 - Consular Attestation
 - Power of Attorney
 - One Way Travel Document
 - NRN Identity Card
+- Renunciation of Nepali Citizenship
 
 ## Jurisdiction
 
-Jurisdictional coverage for the Consulate General of Nepal in Dallas is being finalized. Please contact the consulate for the latest guidance on supported states.
+Jurisdictional coverage for the Consulate General of Nepal in Dallas is being finalized. Contact the consulate at info@nepalconsulatedallas.org for the latest guidance on supported states.
+
+{: .info }
+If you are unsure which consulate serves your state, contact the Embassy of Nepal in Washington, DC at +1 (202) 774-4780.
+
+## Fee Schedule
+
+### E-Passport Fees
+
+| Service | Fee (USD) |
+|---|---|
+| 34-page passport (renewal) | $150 |
+| 66-page passport (renewal) | $200 |
+| 34-page passport (lost or damaged) | $225 |
+| Minor under 10 years (renewal) | $75 |
+
+### Consular Attestation Fees
+
+| Service | Fee (USD) |
+|---|---|
+| Birth certificate attestation | $50 |
+| Marriage certificate attestation | $50 |
+| Death certificate attestation | $50 |
+| Relationship certificate attestation | $50 |
+| Police clearance certificate | $100 |
+
+### Power of Attorney Fees
+
+| Service | Fee (USD) |
+|---|---|
+| Land/house transfer to family (within 3 generations) | $5 |
+| All other Power of Attorney cases | $40 |
+
+**Payment methods:** Cashier's check or money order only, payable to **"CONSULATE GENERAL OF NEPAL DALLAS"**. Cash, personal checks, and cards are not accepted.
+
+> Fees are subject to change. Always confirm with the consulate before your visit.
+
+## Document Checklists
+
+### Consular Attestation
+
+✓ Duly filled attestation application form  
+✓ Original document plus photocopy  
+✓ Applicant's passport and citizenship certificate (copies)  
+✓ Proof of US immigration status (visa, Green Card, etc.)  
+✓ Fee payment via cashier's check or money order  
+✓ Self-addressed, pre-paid return envelope with tracking (if applying by mail)  
+
+**For marriage certificates, also include:**
+✓ Copies of both spouses' passports and citizenship certificates  
+
+**For police clearance certificates, also include:**
+✓ Color printed copy of the police report issued by Nepal Police, attested by the Department of Consular Services of Nepal  
+
+**For US-issued documents:** You must first get (1) notarization by a notary public, (2) state-level authentication from the Secretary of State, and (3) federal authentication from the US Department of State — before submitting to the consulate.
+
+**Processing time:** Up to 3 business days.
+
+### Power of Attorney
+
+✓ Two copies of POA on traditional Nepali paper (Nepali Kagaj) prepared by registered Nepal lawyer  
+✓ Application addressed to Consul General  
+✓ Nepali citizenship certificate (original + copy) for both parties  
+✓ Passport (original + copy)  
+✓ Green Card or visa status documentation (original + copy)  
+✓ Copy of assigned person's citizenship certificate  
+✓ Two passport-sized photos of both parties  
+✓ All document copies must be self-attested and signed with date  
+
+**Additional documents by purpose:**
+- *Land sales:* Land ownership certificate copy + latest tax receipt
+- *Divorce:* Original marriage certificate + copy
+- *Vehicle/business transfer:* Ownership certificates, relationship certificate, tax documents
+
+**Restrictions:** Power of Attorney services are **not available** to foreign nationals, including those of Nepali origin who hold foreign citizenship.
+
+### E-Passport Application
+
+✓ Complete online application at [emrtds.nepalpassport.gov.np](https://emrtds.nepalpassport.gov.np/)  
+✓ Current passport (original + photocopy)  
+✓ Nepali citizenship certificate (original + photocopy)  
+✓ Proof of US immigration status (visa, Green Card, etc.)  
+✓ Printed appointment confirmation  
+✓ Fee payment via cashier's check or money order  
+
+## Appointment Booking
+
+1. **Passport:** Complete the online application at [emrtds.nepalpassport.gov.np](https://emrtds.nepalpassport.gov.np/). Set your device timezone to "Kathmandu" before starting. Select **"NCG, Dallas"** when booking your appointment. Complete the form within 30 minutes. Print the pre-enrollment form with QR code. You must appear in person at the consulate for biometrics on your appointment date.
+2. **Power of Attorney:** Submit complete application with documents via email to secretary@nepalconsulatedallas.org. Wait for appointment confirmation email. Applicant must appear in person.
+3. **Consular Attestation:** Walk-in during the 10:00 AM - 12:30 PM window, or mail your application to the consulate address.
+4. **Other services:** Use the dedicated service emails listed above to route your inquiry to the correct team.
 
 ## Important Information
 
-- Use the dedicated service emails to route general, passport, consular, and power of attorney inquiries to the correct team.
-- Passport appointments must be scheduled in advance; arrive at the booked time slot.
-- Consular attestation services are processed during the 10:00 AM - 12:30 PM window.
-- Office operations pause for lunch between 1:00 PM and 2:00 PM.
+- Use the dedicated service emails to route inquiries to the correct team
+- Passport appointments must be scheduled in advance; arrive at the booked time slot
+- Consular attestation services are processed during the 10:00 AM - 12:30 PM window only
+- Office operations pause for lunch between 1:00 PM and 2:00 PM
+- Always include a self-addressed, pre-paid return envelope with tracking for mail-in applications
 
 ## Forms and Documents
 
@@ -58,21 +152,39 @@ Jurisdictional coverage for the Consulate General of Nepal in Dallas is being fi
 
 ## Frequently Asked Questions
 
-1. How do I schedule a passport appointment?
-   - Submit an online e-passport application and book an appointment time; attend at the scheduled slot with required documents.
+1. **How do I schedule a passport appointment?**
+   - Complete the online application at [emrtds.nepalpassport.gov.np](https://emrtds.nepalpassport.gov.np/), select "NCG, Dallas" as your location, and book an appointment. Set your timezone to "Kathmandu" and complete within 30 minutes. Attend at the scheduled slot with required documents.
 
-2. Which email should I use for service queries?
-   - General questions: info@nepalconsulatedallas.org  
-     Passport services: passport@nepalconsulatedallas.org  
-     Document attestation and consular matters: consular@nepalconsulatedallas.org  
-     Power of Attorney: secretary@nepalconsulatedallas.org
+2. **Which email should I use for service queries?**
+   - General questions: info@nepalconsulatedallas.org
+   - Passport services: passport@nepalconsulatedallas.org
+   - Document attestation and consular matters: consular@nepalconsulatedallas.org
+   - Power of Attorney: secretary@nepalconsulatedallas.org
 
-3. When can I visit for consular attestation?
+3. **When can I visit for consular attestation?**
    - The attestation counter operates from 10:00 AM to 12:30 PM on business days.
 
-4. Does the consulate close for lunch?
+4. **Does the consulate close for lunch?**
    - Yes, the office observes a lunch break from 1:00 PM to 2:00 PM.
+
+5. **What payment methods are accepted?**
+   - Cashier's check or money order only, payable to "CONSULATE GENERAL OF NEPAL DALLAS". Cash and cards are not accepted.
+
+6. **How long does attestation take?**
+   - Up to 3 business days.
 
 ## Sources
 
-- [Consulate General of Nepal, Dallas Official Website](https://dls.nepalconsulate.gov.np) - Last checked: March 2026 (Contact details, Office Hours, Services overview and application guidance; Visa Service and NRN ID Card service confirmed active)
+- [Consulate General of Nepal, Dallas Official Website](https://dls.nepalconsulate.gov.np) — Last checked: March 2026
+  - Contact details, office hours, services overview confirmed
+- [Consular Attestation Page](https://dls.nepalconsulate.gov.np/pages/consular-authentication-6/) — Fees, documents, and processing time confirmed: March 2026
+- [Power of Attorney Page](https://dls.nepalconsulate.gov.np/pages/power-of-attorney-7/) — Fees, documents, and restrictions confirmed: March 2026
+- [NRN ID Card Page](https://dls.nepalconsulate.gov.np/pages/non-resident-identification-card-9/) — Service confirmed active: March 2026
+- [Nepal Embassy — Consulates in America](https://us.nepalembassy.gov.np/pages/consulates-general-in-america-18/) — Address and phone cross-referenced: March 2026
+
+---
+
+> **Help keep this page accurate.**
+> Found something wrong or outdated? [Report it here](https://github.com/kshitu92/dutawas/issues/new?template=outdated_info.md&title=Outdated+Info:+Dallas&labels=outdated).
+
+---

--- a/consulates/new-york.md
+++ b/consulates/new-york.md
@@ -4,24 +4,30 @@ layout: default
 nav_order: 1
 parent: Consulates
 permalink: /consulates/new-york/
+last_verified: 2026-03-16
+verified_by: bishantt
 ---
 # Consulate General of Nepal in New York
 
 ## Location and Contact Information
 
-*Address:*  
-820 Second Avenue, Suite 202  
+**Address:**  
+228 E 45th Street, 4th Floor  
 New York, NY 10017  
 United States of America
 
-*Phone:*  
-+1 (212) 370-3988  
-+1 (212) 370-3989
+**Phone:**  
++1 (917) 675-6783 (Main)  
++1 (917) 723-0005 (Information)  
++1 (914) 447-8548 (Consul General)  
++1 (646) 358-9401 (Deputy Consul General / Spokesperson)  
++1 (917) 340-7191 (Deputy Consul General)
 
-*Email:*  
-cgnnewyork@mofa.gov.np
+**Email:**  
+cgnnewyork@mofa.gov.np  
+nepal.cgnny@gmail.com
 
-*Office Hours:*  
+**Office Hours:**  
 Monday to Friday: 9:00 AM - 5:00 PM  
 Consular Services Window: 9:30 AM - 2:30 PM  
 (Closed on Saturdays, Sundays, and Public Holidays)
@@ -30,64 +36,155 @@ Consular Services Window: 9:30 AM - 2:30 PM
 
 - E-Passport Services
 - Power of Attorney
-- NRN ID
+- NRN ID Card
 - Visa Services
 - One Way Travel Document
 - No Objection Letter for Dead Body Repatriation
-- Document Attestation
+- Document Attestation (Birth, Marriage, Death, Relationship Certificates)
+- Affidavit Attestation
 
 ## Jurisdiction
 
 The Consulate General of Nepal in New York serves the following states:
-- New York
-- New Jersey
 - Connecticut
-- Pennsylvania
+- Maine
 - Massachusetts
+- New Hampshire
+- New Jersey
+- New York
+- Pennsylvania
 - Rhode Island
 - Vermont
-- New Hampshire
-- Maine
 
 Residents of all other US states should contact the Embassy of Nepal in Washington, DC.
 
+## Fee Schedule
+
+### E-Passport Fees
+
+| Service | Fee (USD) |
+|---|---|
+| 34-page passport (renewal) | $150 |
+| 66-page passport (renewal) | $200 |
+| 34-page passport (lost or damaged) | $225 |
+| Minor under 10 years (renewal) | $75 |
+| Minor under 10 years (lost/damaged) | $113 |
+
+### Other Consular Fees
+
+| Service | Fee (USD) |
+|---|---|
+| Power of Attorney | $40 |
+| Document Attestation (Birth, Marriage, Death, Relationship) | $50 per document |
+| Affidavit Attestation | $100 |
+
+**Payment methods:** Money order or cashier's check only. Cash, personal checks, and credit/debit cards are **not** accepted.
+
+> Fees are subject to change. Always confirm with the consulate before your visit.
+
+## Document Checklists
+
+### E-Passport Renewal
+
+✓ Current passport (original + photocopy of data pages 2-3 and 30-31)  
+✓ Nepali citizenship certificate (original + photocopy, front and back)  
+✓ Printed confirmation from online application at [emrtds.nepalpassport.gov.np](https://emrtds.nepalpassport.gov.np/)  
+✓ Marriage certificate (if surname changed)  
+✓ Migration certificate (if address differs from citizenship card)  
+✓ Fee payment via money order or cashier's check  
+
+**For minors (under 16):**
+✓ Minor identity certificate  
+✓ Previous passport  
+✓ Both parents' citizenship certificates  
+✓ Parents' marriage certificate  
+
+### Document Attestation
+
+✓ Original certificate issued by local ward authorities, verified by concerned municipality  
+✓ Valid Nepali passport and citizenship certificate  
+✓ Fee payment ($50 per certification) via money order or cashier's check  
+✓ Self-addressed, pre-paid return envelope with tracking (for postal applications)  
+
+**Important:** The consulate does not issue certificates. It can issue a "To Whom It May Concern" letter with supporting documentation. For US-issued documents, you must first get notarization, then state Secretary of State authentication, then US Department of State authentication before consulate processing.
+
+### Power of Attorney
+
+✓ Original Power of Attorney prepared by a registered Nepal attorney on Nepali paper (two copies)  
+✓ Application addressed to the Consul General  
+✓ Nepali citizenship certificate (original + photocopy) for both parties  
+✓ Passport (original + photocopy)  
+✓ Current fiscal year property tax receipt (if property-related)  
+✓ Two recent color passport-sized photos per person  
+✓ Property ownership certificates, if applicable (notarized)  
+✓ Three-generation details for both grantor and grantee  
+
+**Restrictions:** Power of Attorney services are **not available** to US citizens or US passport holders of Nepali origin.
+
+## Appointment Booking
+
+1. **E-Passport:** Complete the online application at [emrtds.nepalpassport.gov.np](https://emrtds.nepalpassport.gov.np/). Set your device timezone to "Kathmandu" before starting. Select **"NPM New York"** when booking your appointment. Complete the form within 15 minutes. Print the pre-enrollment form with QR code. You must appear in person at the consulate for biometrics on your appointment date.
+2. **Power of Attorney:** Schedule by email at cgnny.consul@gmail.com. Grantor must appear in person.
+3. **Other services:** Contact the consulate by email to schedule.
+
+**Processing time:** E-passport applications take approximately 6-8 weeks after the biometric appointment. Delivery is via pre-paid return envelope or in-person pickup.
+
+## Consular Service Camps
+
+The New York consulate holds periodic consular service camps in its jurisdiction states, providing expanded service access outside Manhattan. Recent camps have been held in Pennsylvania and New Hampshire. Check the [consulate website](https://nyc.nepalconsulate.gov.np) for upcoming camp dates.
+
 ## Important Information
 
-- Emergency Registration: Please fill out the emergency registration form if you are affected by COVID-19
-- Professional Support: Business professionals willing to support the Nepali community can submit their details
-- Consular Services: All consular services require prior appointment
-- Document Processing: Processing times may vary depending on the type of service
+- All consular services require prior appointment
+- Document processing times may vary depending on the type of service
 
 ## Forms and Documents
 
-- Emergency Registration Form
-- Professional Support Form
-- Passport Application Forms
+- [E-Passport Online Application Portal](https://emrtds.nepalpassport.gov.np/)
+- Passport Application Forms (available at consulate)
 - Visa Application Forms
 - NRN ID Application Forms
 
 ## Frequently Asked Questions
 
-1. How do I schedule an appointment?
-   - Appointments can be scheduled through the consulate's website or by phone
+1. **How do I schedule an appointment?**
+   - For e-passport: apply online at [emrtds.nepalpassport.gov.np](https://emrtds.nepalpassport.gov.np/) and select "NPM New York"
+   - For other services: email cgnnewyork@mofa.gov.np
 
-2. What documents are required for passport renewal?
-   - Current passport
-   - Proof of residence
-   - Passport-sized photographs
-   - Completed application form
+2. **What documents are required for passport renewal?**
+   - Current passport (original + photocopy)
+   - Citizenship certificate (original + photocopy)
+   - Printed online application confirmation
+   - Fee via money order or cashier's check ($150 for 34-page, $200 for 66-page)
 
-3. How long does it take to process a visa application?
-   - Processing time varies but typically takes 3-5 business days
+3. **How long does passport processing take?**
+   - Approximately 6-8 weeks
 
-4. What are the consulate's public holidays?
+4. **What payment methods are accepted?**
+   - Money order or cashier's check only. Cash, personal checks, and cards are not accepted.
+
+5. **What are the consulate's public holidays?**
    - The consulate observes both Nepali and American public holidays
    - Check the website for the current year's holiday schedule
 
+6. **I live in Boston/New England — do I have to go to New York?**
+   - The consulate holds periodic service camps in New England and nearby states. Check the website for upcoming camp dates. For document attestation, you may apply by mail with a pre-paid return envelope. E-passport applications require an in-person visit for biometrics.
+
 ## Sources
 
-- [Consulate General of Nepal, New York Official Website](https://nyc.nepalconsulate.gov.np) - Last checked: March 2026
-  - Contact Information (email updated to cgnnewyork@mofa.gov.np)
-  - Services
-  - Jurisdiction (verified: CT, ME, MA, NH, NJ, NY, PA, RI, VT)
-  - Office Hours (updated: 9:00 AM–5:00 PM, Consular: 9:30 AM–2:30 PM) 
+- [Consulate General of Nepal, New York Official Website](https://nyc.nepalconsulate.gov.np) — Last checked: March 2026
+  - Address confirmed: 228 E 45th Street, 4th Floor (consulate relocated from former address at 820 Second Avenue)
+  - Phone numbers updated per official website
+  - Services and jurisdiction confirmed (CT, ME, MA, NH, NJ, NY, PA, RI, VT)
+  - Office hours confirmed (9:00 AM–5:00 PM, Consular: 9:30 AM–2:30 PM)
+- [E-Passport Service Page](https://nyc.nepalconsulate.gov.np/pages/e-passport-1) — Fees and document requirements confirmed: March 2026
+- [Document Attestation Page](https://nyc.nepalconsulate.gov.np/pages/document-attestation-7) — Fees and types confirmed: March 2026
+- [Power of Attorney Page](https://nyc.nepalconsulate.gov.np/pages/power-of-attorney-4) — Fees, documents, and restrictions confirmed: March 2026
+
+
+---
+
+> **Help keep this page accurate.**
+> Found something wrong or outdated? [Report it here](https://github.com/kshitu92/dutawas/issues/new?template=outdated_info.md&title=Outdated+Info:+New+York&labels=outdated).
+
+---

--- a/consulates/washington-state.md
+++ b/consulates/washington-state.md
@@ -4,89 +4,138 @@ layout: default
 nav_order: 2
 parent: Consulates
 permalink: /consulates/washington-state/
+last_verified: 2026-03-16
+verified_by: bishantt
 ---
 # Office of Nepal Consulate in Washington State
 
 ## Location and Contact Information
 
-*Address:*  
+**Address:**  
 Bellevue Technology Center  
 2018 156th Ave NE, Suite 126  
 Bellevue, WA 98007  
 United States of America
 
-*Phone:*  
+{: .info }
+Some directories list an alternate address at 16300 Redmond Way NE, Suite 201, Redmond, WA 98052. Call +1 (206) 324-9000 to confirm the current office location before visiting.
+
+**Phone:**  
 +1 (206) 324-9000
 
-*Email:*  
-info@nepalconsulate.org
+**Email:**  
+nepalconsulate@gmail.com
 
-*Office Hours:*  
-Please check the official website or call ahead for current hours.  
+**Office Hours:**  
+Please check the [official website](https://nepalconsulate.org) or call ahead for current hours.  
 Appointments are recommended for all services.
+
+**Honorary Consul General:** Mr. AC Sherpa
 
 ## Services Provided
 
-- Diplomatic Visa Services
-- Official Visa Services
-- Business Visa Services
-- Tourist Visa Services
+- Visa Application Services
 - Public Notarial Services
 - Document Processing
 - Consular Services
 
 ## Jurisdiction
 
-The Office of Nepal Consulate in Washington State serves the following areas:
+The Office of Nepal Consulate in Washington State serves:
 - Washington State
-- [Additional areas to be confirmed]
+- Additional areas — contact the consulate for confirmation
+
+{: .info }
+This is an honorary consulate with more limited services than the Consulate General offices in New York and Dallas. For e-passport and other major consular services, contact the [Embassy of Nepal in Washington, DC](https://us.nepalembassy.gov.np) at +1 (202) 774-4780.
+
+## Fee Schedule
+
+| Service | Fee (USD) |
+|---|---|
+| Notary service | $15 per document |
+| Visa services | Check with consulate for current rates |
+
+**Payment methods:** Contact the consulate for accepted payment methods.
+
+> Fees are subject to change. Always confirm with the consulate before your visit.
+
+## Document Checklists
+
+### Notary Services
+
+✓ Washington state ID card or passport  
+✓ Original documents to be notarized  
+✓ $15 fee per document  
+
+### Visa Application
+
+✓ Completed visa application form  
+✓ Valid passport  
+✓ Passport-sized photographs  
+✓ Fee payment  
+✓ Supporting documents based on visa type (business letter, invitation, itinerary, etc.)  
+
+Online visa application portal: [nepaliport.immigration.gov.np](https://nepaliport.immigration.gov.np/)
+
+## Appointment Booking
+
+Appointments can be scheduled through the [consulate's website](https://nepalconsulate.org).
+
+## Consular Service Camps
+
+The consulate periodically organizes consular service camps for expanded access. A recent camp was held May 30 - June 3, 2024 at the Hilton Garden Redmond (16630 Redmond Way, Redmond, WA 98052). Check the [consulate website](https://nepalconsulate.org) for upcoming camp dates and locations.
 
 ## Important Information
 
+- This is an honorary consulate — services may be more limited than at a Consulate General
 - Public Notarial Service: Authorized by Washington state Huckleberry Notary Bonding, Inc.
-- Document Requirements: All documents require involvement parties and Washington state ID card or passport
-- Notary Fee: $15 per document
-- Consular Service Camps: Regular service camps are organized (e.g., May 30th - June 3rd, 2024)
+- All documents require involvement parties and Washington state ID card or passport
+- Walk-in services may be available during consular service camps
 
 ## Forms and Documents
 
-- Online Appointment Form
-- Visa Application Forms
-  - Diplomatic Visa
-  - Official Visa
-  - Business Visa
-  - Tourist Visa
+- [Online Visa Application Portal](https://nepaliport.immigration.gov.np/)
+- Visa Application Forms (Diplomatic, Official, Business, Tourist)
 - Notary Service Documents
 - Consular Service Documents
 
 ## Frequently Asked Questions
 
-1. How do I schedule an appointment?
-   - Appointments can be scheduled through the consulate's website
+1. **How do I schedule an appointment?**
+   - Appointments can be scheduled through the [consulate's website](https://nepalconsulate.org)
    - Walk-in services may be available during consular service camps
 
-2. What documents are required for notary services?
+2. **What documents are required for notary services?**
    - Washington state ID card or passport
    - Original documents to be notarized
    - $15 fee per document
 
-3. What are the visa processing times?
-   - Processing times vary by visa type
-   - Check the website for current processing times
+3. **What are the visa processing times?**
+   - Processing times vary by visa type. Check the website for current processing times.
 
-4. Are there any upcoming consular service camps?
-   - Regular service camps are organized
-   - Check the website for upcoming camp dates and locations
+4. **Can I get an e-passport here?**
+   - This honorary consulate does not process e-passport applications. Contact the [Embassy of Nepal in Washington, DC](https://us.nepalembassy.gov.np) at +1 (202) 774-4780 for e-passport services.
+
+5. **Are there any upcoming consular service camps?**
+   - The consulate organizes periodic service camps. Check the [website](https://nepalconsulate.org) for upcoming dates and locations.
 
 ## Additional Resources
 
-- Ministry of Foreign Affairs, Nepal
-- Embassy of Nepal in Washington, DC
-- Consulate General of Nepal in New York
+- [Embassy of Nepal, Washington DC](https://us.nepalembassy.gov.np) — +1 (202) 774-4780
+- [Ministry of Foreign Affairs, Nepal](https://mofa.gov.np)
 
 ## Sources
 
-- [Office of Nepal Consulate, Washington State Official Website](https://nepalconsulate.org) - Last checked: March 2026
-  - Contact Information (address, phone, and email confirmed unchanged)
-  - Services
-  - Consular Service Camps 
+- [Office of Nepal Consulate, Washington State Official Website](https://nepalconsulate.org) — Last checked: March 2026
+  - Contact information: address listed as Bellevue Technology Center, phone and email confirmed
+  - Services confirmed
+  - Honorary Consul General: Mr. AC Sherpa confirmed
+  - Consular service camp information confirmed
+- [embassypages.com](https://www.embassypages.com/nepal-consulate-seattle-unitedstates) — Alternate address noted (16300 Redmond Way NE)
+
+---
+
+> **Help keep this page accurate.**
+> Found something wrong or outdated? [Report it here](https://github.com/kshitu92/dutawas/issues/new?template=outdated_info.md&title=Outdated+Info:+Washington+State&labels=outdated).
+
+---

--- a/index.md
+++ b/index.md
@@ -4,8 +4,153 @@ layout: home
 nav_order: 1
 ---
 
-दुतावास (Dutawas) bridges the information gap for Nepali citizens by providing clear, accessible documentation about services offered by the Embassy of Nepal in the United States. 
-
+दुतावास (Dutawas) bridges the information gap for Nepali citizens by providing clear, accessible documentation about services offered by the Embassy of Nepal in the United States.
 
 {: .warning }
-This is an independent, community-maintained resource and is not affiliated with the Government of Nepal or its diplomatic missions. 
+This is an independent, community-maintained resource and is not affiliated with the Government of Nepal or its diplomatic missions.
+
+## Nepali Consulates in the United States
+
+| Location | Phone | Consular Hours | Serves |
+|---|---|---|---|
+| [New York](/consulates/new-york/) | +1 (917) 675-6783 | Mon–Fri 9:30 AM–2:30 PM | NY, NJ, CT, PA, MA, RI, VT, NH, ME |
+| [Dallas](/consulates/dallas/) | +1 (972) 803-5394 | Mon–Fri 10:00 AM–12:30 PM | Being finalized — contact consulate |
+| [Washington State](/consulates/washington-state/) | +1 (206) 324-9000 | Call for hours | WA and region |
+| [Boston](/consulates/boston/) | — | — | Served by New York consulate |
+
+## Which Consulate Serves My State?
+
+<div style="margin: 1rem 0;">
+  <select id="stateSelect" style="padding: 10px; font-size: 1rem; width: 100%; max-width: 400px; border: 1px solid #ccc; border-radius: 4px;">
+    <option value="">-- Select your state --</option>
+    <option value="AL">Alabama</option>
+    <option value="AK">Alaska</option>
+    <option value="AZ">Arizona</option>
+    <option value="AR">Arkansas</option>
+    <option value="CA">California</option>
+    <option value="CO">Colorado</option>
+    <option value="CT">Connecticut</option>
+    <option value="DE">Delaware</option>
+    <option value="DC">District of Columbia</option>
+    <option value="FL">Florida</option>
+    <option value="GA">Georgia</option>
+    <option value="HI">Hawaii</option>
+    <option value="ID">Idaho</option>
+    <option value="IL">Illinois</option>
+    <option value="IN">Indiana</option>
+    <option value="IA">Iowa</option>
+    <option value="KS">Kansas</option>
+    <option value="KY">Kentucky</option>
+    <option value="LA">Louisiana</option>
+    <option value="ME">Maine</option>
+    <option value="MD">Maryland</option>
+    <option value="MA">Massachusetts</option>
+    <option value="MI">Michigan</option>
+    <option value="MN">Minnesota</option>
+    <option value="MS">Mississippi</option>
+    <option value="MO">Missouri</option>
+    <option value="MT">Montana</option>
+    <option value="NE">Nebraska</option>
+    <option value="NV">Nevada</option>
+    <option value="NH">New Hampshire</option>
+    <option value="NJ">New Jersey</option>
+    <option value="NM">New Mexico</option>
+    <option value="NY">New York</option>
+    <option value="NC">North Carolina</option>
+    <option value="ND">North Dakota</option>
+    <option value="OH">Ohio</option>
+    <option value="OK">Oklahoma</option>
+    <option value="OR">Oregon</option>
+    <option value="PA">Pennsylvania</option>
+    <option value="RI">Rhode Island</option>
+    <option value="SC">South Carolina</option>
+    <option value="SD">South Dakota</option>
+    <option value="TN">Tennessee</option>
+    <option value="TX">Texas</option>
+    <option value="UT">Utah</option>
+    <option value="VT">Vermont</option>
+    <option value="VA">Virginia</option>
+    <option value="WA">Washington</option>
+    <option value="WV">West Virginia</option>
+    <option value="WI">Wisconsin</option>
+    <option value="WY">Wyoming</option>
+  </select>
+</div>
+
+<div id="consulate-result" style="margin-top: 1rem; padding: 1rem; border-left: 4px solid #e63329; background: #fef2f2; display: none;">
+</div>
+
+{% raw %}
+<script>
+(function() {
+  var ny = {
+    name: "Consulate General of Nepal, New York",
+    phone: "+1 (917) 675-6783",
+    email: "cgnnewyork@mofa.gov.np",
+    url: "/consulates/new-york/"
+  };
+  var dallas = {
+    name: "Consulate General of Nepal, Dallas",
+    phone: "+1 (972) 803-5394",
+    email: "info@nepalconsulatedallas.org",
+    url: "/consulates/dallas/"
+  };
+  var wa = {
+    name: "Nepal Consulate, Washington State",
+    phone: "+1 (206) 324-9000",
+    email: "nepalconsulate@gmail.com",
+    url: "/consulates/washington-state/",
+    note: "This is an honorary consulate with limited services. For e-passport and major consular services, contact the Embassy in Washington DC."
+  };
+  var dc = {
+    name: "Embassy of Nepal, Washington DC",
+    phone: "+1 (202) 774-4780",
+    email: "info@nepalembassyusa.org",
+    url: "https://us.nepalembassy.gov.np"
+  };
+
+  var mapping = {
+    CT: ny, ME: ny, MA: ny, NH: ny, NJ: ny, NY: ny, PA: ny, RI: ny, VT: ny,
+    TX: dallas,
+    WA: wa,
+    AL: dc, AK: dc, AZ: dc, AR: dc, CA: dc, CO: dc, DE: dc, DC: dc,
+    FL: dc, GA: dc, HI: dc, ID: dc, IL: dc, IN: dc, IA: dc, KS: dc,
+    KY: dc, LA: dc, MD: dc, MI: dc, MN: dc, MS: dc, MO: dc, MT: dc,
+    NE: dc, NV: dc, NM: dc, NC: dc, ND: dc, OH: dc, OK: dc, OR: dc,
+    SC: dc, SD: dc, TN: dc, UT: dc, VA: dc, WV: dc, WI: dc, WY: dc
+  };
+
+  var select = document.getElementById("stateSelect");
+  var result = document.getElementById("consulate-result");
+
+  select.addEventListener("change", function() {
+    var state = select.value;
+    var c = mapping[state];
+    if (c) {
+      var html = "<strong>" + c.name + "</strong><br>" +
+        "Phone: " + c.phone + "<br>" +
+        "Email: <a href='mailto:" + c.email + "'>" + c.email + "</a><br>" +
+        "<a href='" + c.url + "'>View full details &rarr;</a>";
+      if (c.note) {
+        html += "<br><br><em>" + c.note + "</em>";
+      }
+      result.style.display = "block";
+      result.innerHTML = html;
+    } else {
+      result.style.display = "none";
+    }
+  });
+})();
+</script>
+{% endraw %}
+
+## Emergency Contacts
+
+| Office | Phone | For |
+|---|---|---|
+| Embassy of Nepal, Washington DC | +1 (202) 774-4780 | All US residents |
+| Consulate General, New York | +1 (917) 675-6783 | Eastern states |
+| Consulate General, Dallas | +1 (972) 803-5394 | Southern states |
+| Nepal Police Emergency | 100 | Emergencies in Nepal |
+| Ministry of Foreign Affairs | +977-1-4200163 | Nepal government |
+| MoFA Toll Free (from Nepal) | 1660-01-00186 | Nepal government |


### PR DESCRIPTION
Hey @kshitu92 — I'm Nepali, based in the US, and found Dutawas on your facebook story. Loved the idea, noticed some gaps, so I went ahead and fixed what I could.

What I found and fixed:

- NY consulate moved to 228 E 45th Street (4th Floor) and their main number is now (917) 675-6783 — the old 820 Second Ave address and (212) 370-3988 are outdated. Worth noting: 820 Second Avenue is actually the UN Mission of Nepal, not the consulate — easy to mix up. Confirmed the correct address directly by calling the consulate office.
- Embassy DC phone updated to (202) 774-4780
- Washington State email corrected to [nepalconsulate@gmail.com](mailto:nepalconsulate@gmail.com)

Beyond corrections, I added fee tables, document checklists for common services (passport renewal, attestation, power of attorney), and appointment booking steps per consulate — each one has a different process. Everything is sourced from official sites with last-checked dates.

The homepage had no quick way to figure out which consulate to even contact, so I added a consulate reference table, a state-to-consulate mapping, and emergency contacts.

I also added a "Flag as outdated" link on every page that opens a pre-filled GitHub Issue — this info goes stale fast and figured it'd help the community keep things current without needing to know Git. Included two issue templates and a CONTRIBUTING.md for non-technical folks.

Files changed: consulates/new-york.md, consulates/dallas.md, consulates/washington-state.md, consulates/boston.md, index.md, CONTRIBUTING.md, .github/ISSUE_TEMPLATE/outdated_info.md, .github/ISSUE_TEMPLATE/new_content.md
Have a few more ideas (folder structure for multi-country, a date converter tool, bilingual support) but those are bigger conversations — will raise them separately. Let me know if anything looks off.